### PR TITLE
Update runtime to 6.10

### DIFF
--- a/org.kde.dragonplayer.json
+++ b/org.kde.dragonplayer.json
@@ -37,15 +37,5 @@
                 }
             ]
         }
-    ],
-    "add-extensions": {
-        "org.freedesktop.Platform.ffmpeg-full": {
-            "version": "24.08",
-            "directory": "lib/ffmpeg",
-            "add-ld-path": "."
-        }
-    },
-    "cleanup-commands": [
-        "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
     ]
 }


### PR DESCRIPTION
Renamed main module to `dragon` to follow Flatpak/Flathub conventions.

`openh264` and `ffmpeg-full` have been replaced by the `codecs-extra` runtime extension in Freedesktop runtime 25.08, which KDE runtime 6.10 is based on. `codecs-extra` is installed automatically, so this can be removed from the manifest.

This leads to this (incorrect) error:

<img width="1012" height="780" alt="Screenshot From 2025-11-16 00-42-30" src="https://github.com/user-attachments/assets/eb3ae9c1-9153-42a3-a5e7-ce4491b36dcd" />

This should be fixed upstream, I guess, although it could be patched out for the flatpak build.